### PR TITLE
fix: add model bug

### DIFF
--- a/clients/go/jams/grpc/client_test.go
+++ b/clients/go/jams/grpc/client_test.go
@@ -54,6 +54,8 @@ func TestDeleteModel(t *testing.T) {
 	assert.Nil(t, err)
 
 	// Act
+	err = client.AddModel(ctx, &jams.AddModelRequest{ModelName: "pytorch-my_awesome_californiahousing_model"})
+	assert.NoError(t, err)
 	err = client.DeleteModel(ctx, &jams.DeleteModelRequest{ModelName: "my_awesome_californiahousing_model"})
 
 	// Assert

--- a/clients/go/jams/http/client_test.go
+++ b/clients/go/jams/http/client_test.go
@@ -48,7 +48,9 @@ func TestDeleteModel(t *testing.T) {
 	client := New(getURL())
 
 	// Act
-	err := client.DeleteModel(ctx, "my_awesome_californiahousing_model")
+	err := client.AddModel(ctx, &AddModelRequest{ModelName: "pytorch-my_awesome_californiahousing_model"})
+	assert.NoError(t, err)
+	err = client.DeleteModel(ctx, "my_awesome_californiahousing_model")
 
 	// Assert
 	assert.NoError(t, err)

--- a/clients/python/jams/tests/client/grpc/test_models.py
+++ b/clients/python/jams/tests/client/grpc/test_models.py
@@ -23,6 +23,7 @@ def test_successfully_makes_delete_model_request() -> None:
     grpc_client = grpc.Client(base_url)
 
     # Act
+    grpc_client.add_model(model_name="pytorch-my_awesome_californiahousing_model")
     grpc_client.delete_model(model_name="my_awesome_californiahousing_model")
 
     # Assert

--- a/clients/python/jams/tests/client/http/test_models.py
+++ b/clients/python/jams/tests/client/http/test_models.py
@@ -23,6 +23,7 @@ def test_successfully_makes_delete_model_request() -> None:
     http_client = http.Client(base_url)
 
     # Act
+    http_client.add_model(model_name="pytorch-my_awesome_californiahousing_model")
     http_client.delete_model(model_name="my_awesome_californiahousing_model")
 
     # Assert

--- a/clients/rust/jams-client/src/grpc.rs
+++ b/clients/rust/jams-client/src/grpc.rs
@@ -189,6 +189,10 @@ mod tests {
 
         // Act
         let resp = client
+            .add_model("pytorch-my_awesome_californiahousing_model".to_string())
+            .await;
+        
+        let resp = client
             .delete_model("my_awesome_californiahousing_model".to_string())
             .await;
 

--- a/clients/rust/jams-client/src/http.rs
+++ b/clients/rust/jams-client/src/http.rs
@@ -241,7 +241,8 @@ mod tests {
         // Act
         let resp = client
             .add_model("pytorch-my_awesome_californiahousing_model".to_string())
-            .await;
+            .await
+            .unwrap();
 
         let resp = client
             .delete_model("my_awesome_californiahousing_model".to_string())

--- a/clients/rust/jams-client/src/http.rs
+++ b/clients/rust/jams-client/src/http.rs
@@ -240,6 +240,10 @@ mod tests {
 
         // Act
         let resp = client
+            .add_model("pytorch-my_awesome_californiahousing_model".to_string())
+            .await;
+
+        let resp = client
             .delete_model("my_awesome_californiahousing_model".to_string())
             .await;
 

--- a/jams-core/src/model_store/azure_blob_storage.rs
+++ b/jams-core/src/model_store/azure_blob_storage.rs
@@ -800,8 +800,7 @@ mod tests {
 
         // assert
         assert!(add.is_ok());
-        // todo: this is a bug which needs to fixed. When adding model the framework prefix should be removed
-        let model = model_store.get_model("catboost-titanic_model".to_string());
+        let model = model_store.get_model("titanic_model".to_string());
         assert!(model.is_some());
         assert_eq!(num_models_after_add - num_models, 1);
 

--- a/jams-core/src/model_store/local.rs
+++ b/jams-core/src/model_store/local.rs
@@ -2,7 +2,8 @@ use crate::model_store::common::{
     cleanup, unpack_tarball, DOWNLOADED_MODELS_DIRECTORY_NAME_PREFIX,
 };
 use crate::model_store::storage::{
-    extract_framework_from_path, load_models, load_predictor, Metadata, Model, ModelName, Storage,
+    append_model_format, extract_framework_from_path, load_models, load_predictor, Metadata, Model,
+    ModelName, Storage,
 };
 use async_trait::async_trait;
 use chrono::Utc;
@@ -129,35 +130,48 @@ impl Storage for LocalModelStore {
         let lms_model_name = format!("{}.tar.gz", model_name.clone());
 
         let local_model_store_path = format!("{}/{}", self.local_model_store_dir, lms_model_name);
-
         unpack_tarball(
             local_model_store_path.as_str(),
             self.temp_model_dir.as_str(),
         )?;
 
-        let model_path = format!("{}/{}", self.temp_model_dir, model_name);
-
-        match extract_framework_from_path(model_path.clone()) {
+        // Extract model framework
+        let model_framework = match extract_framework_from_path(model_name.clone()) {
             None => {
                 anyhow::bail!("Failed to extract framework from path");
             }
-            Some(framework) => match load_predictor(framework, model_path.as_str()).await {
-                Ok(predictor) => {
-                    let now = Utc::now();
-                    let model = Model::new(
-                        predictor,
-                        model_name.clone(),
-                        framework,
-                        model_path.to_string(),
-                        now.to_rfc2822(),
-                    );
-                    self.models.insert(model_name, Arc::new(model));
-                    Ok(())
-                }
-                Err(e) => {
-                    anyhow::bail!("Failed to add new model: {e}")
-                }
-            },
+            Some(model_framework) => model_framework,
+        };
+
+        let model_path = append_model_format(
+            model_framework,
+            format!("{}/{}", self.temp_model_dir, model_name.clone()),
+        );
+
+        match load_predictor(model_framework, model_path.as_str()).await {
+            Ok(predictor) => {
+                let sanitized_model_name =
+                    match model_name.strip_prefix(format!("{}-", model_framework).as_str()) {
+                        None => {
+                            anyhow::bail!("Failed to sanitize model name");
+                        }
+                        Some(name) => name.to_string(),
+                    };
+
+                let now = Utc::now();
+                let model = Model::new(
+                    predictor,
+                    sanitized_model_name.clone(),
+                    model_framework,
+                    model_path.to_string(),
+                    now.to_rfc2822(),
+                );
+                self.models.insert(sanitized_model_name, Arc::new(model));
+                Ok(())
+            }
+            Err(e) => {
+                anyhow::bail!("Failed to add new model: {e}")
+            }
         }
     }
 

--- a/jams-core/src/model_store/local.rs
+++ b/jams-core/src/model_store/local.rs
@@ -445,7 +445,7 @@ mod tests {
 
         // assert
         assert!(add.is_ok());
-        let model = local_model_store.get_model("tensorflow-my_awesome_penguin_model".to_string());
+        let model = local_model_store.get_model("my_awesome_penguin_model".to_string());
         assert!(model.is_some());
         assert_eq!(num_models_after_add - num_models, 1);
     }

--- a/jams-core/src/model_store/s3.rs
+++ b/jams-core/src/model_store/s3.rs
@@ -876,8 +876,7 @@ mod tests {
 
         // assert
         assert!(add.is_ok());
-        // todo: this is a bug which needs to fixed. When adding model the framework prefix should be removed
-        let model = model_store.get_model("catboost-titanic_model".to_string());
+        let model = model_store.get_model("titanic_model".to_string());
         assert!(model.is_some());
         assert_eq!(num_models_after_add - num_models, 1);
 

--- a/jams-core/src/model_store/s3.rs
+++ b/jams-core/src/model_store/s3.rs
@@ -195,37 +195,46 @@ impl Storage for S3ModelStore {
         // If pytorch -> append '.pt'
         // If lightgbm -> append '.txt'
 
-        // We will not be using the model_path from the request
-        // as we have all the information to load the model
-        let model_path = format!("{}/{}", self.model_store_dir, model_name);
-
-        // Load the model into memory
-        match extract_framework_from_path(model_path.clone()) {
+        // Extract model framework
+        let model_framework = match extract_framework_from_path(model_name.clone()) {
             None => {
                 anyhow::bail!("Failed to extract framework from path");
             }
-            Some(framework) => match load_predictor(
-                framework,
-                append_model_format(framework, model_path.clone()).as_str(),
-            )
-            .await
-            {
-                Ok(predictor) => {
-                    let now = Utc::now();
-                    let model = Model::new(
-                        predictor,
-                        model_name.clone(),
-                        framework,
-                        model_path.to_string(),
-                        now.to_rfc2822(),
-                    );
-                    self.models.insert(model_name, Arc::new(model));
-                    Ok(())
-                }
-                Err(e) => {
-                    anyhow::bail!("Failed to add new model: {e}")
-                }
-            },
+            Some(model_framework) => model_framework,
+        };
+
+        // We will not be using the model_path from the request
+        // as we have all the information to load the model
+        let model_path = append_model_format(
+            model_framework,
+            format!("{}/{}", self.model_store_dir, model_name.clone()),
+        );
+
+        // Load the model into memory
+        match load_predictor(model_framework, model_path.as_str()).await {
+            Ok(predictor) => {
+                let sanitized_model_name =
+                    match model_name.strip_prefix(format!("{}-", model_framework).as_str()) {
+                        None => {
+                            anyhow::bail!("Failed to sanitize model name");
+                        }
+                        Some(name) => name.to_string(),
+                    };
+
+                let now = Utc::now();
+                let model = Model::new(
+                    predictor,
+                    sanitized_model_name.clone(),
+                    model_framework,
+                    model_path.to_string(),
+                    now.to_rfc2822(),
+                );
+                self.models.insert(sanitized_model_name, Arc::new(model));
+                Ok(())
+            }
+            Err(e) => {
+                anyhow::bail!("Failed to add new model: {e}")
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug when calling `add_model ` via` HTTP/gRPC`. Basically, the request would fail if the model name after extracting the tar had a suffix i.e model format (example: model.pt). Additionally, if a model which do not require a suffix were added, the name would be wrong as the `model_framework` would also be part of the name.

Also makes the test idempotent