### PR TITLE
fat: implement config file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,14 +2019,16 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jams"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "clap",
  "jams-core",
  "jams-serve",
  "log",
+ "serde",
  "tokio",
+ "toml",
  "tracing",
 ]
 
@@ -3251,6 +3253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +3719,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4281,6 +4326,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xattr"

--- a/README.md
+++ b/README.md
@@ -53,18 +53,66 @@ Please refer to examples for different types of setup.
 
 (🚧) **J.A.M.S** also provides HTTP & gRPC client implementations in multiple languages. [See here](https://github.com/gagansingh894/jams-rs/tree/main/clients)
 
-⚠️ **DISCLAIMER: jams is currently unstable and may not run properly on your machines. I have
-tested the above on Apple Silicon and Linux x86_64 machines. Future releases will fix this**
+⚠️ **DISCLAIMER: jams is currently unstable and may not run properly on ARM chips. Future releases will fix this.
+For now use docker image (Linux x86_64)**
 
 ---
 
 ## Docker Setup
-J.A.M.S is also hosted on [DockerHub](https://hub.docker.com/r/gagansingh894/jams).
+J.A.M.S is hosted on [DockerHub](https://hub.docker.com/r/gagansingh894/jams).
 
+`docker pull gagansingh894/jams`
+
+The easiest way to start J.A.M.S is by providing a config TOML file
+
+##### Config File
+```
+[config]
+protocol = "http"                               # Specifies the protocol to be used by the server.
+                                                # Allowed values: "http", "grpc"
+
+port = 3000                                     # Defines the port number on which the server will listen.
+                                                # This should be an integer between 1 and 65535.
+                                                # Example: 3000 for HTTP, 443 for HTTPS
+
+model_store = "local"                           # Indicates the type of model store being used.
+                                                # Allowed values:
+                                                # - "local": Use local storage.
+                                                # - "aws": Use AWS S3 for model storage.
+                                                # - "azure": Use Azure Blob Storage.
+
+model_dir = "<absolute path>"                   # Specifies the directory path where models are stored locally.
+                                                # If `model_store` is set to "local", this directory is used
+                                                # to store or load models.
+
+azure_storage_container_name = "jamsmodelstore" # Specifies the name of the Azure Blob Storage container
+                                                # used for storing models when `model_store` is set to "azure".
+                                                # This should be a valid container name in Azure.
+
+s3_bucket_name = "jamsmodelstore"               # Indicates the name of the S3 bucket used for storing models
+                                                # when `model_store` is set to "aws".
+                                                # This should be a valid bucket name in AWS S3.
+
+poll_interval = 600                             # Defines the time interval (in seconds) for polling the model store
+                                                # to check for updates.
+                                                # Example: 600 means the application will poll every 10 minutes.
+
+num_workers = 4                                 # Sets the number of Rayon threadpool worker threads
+                                                # Example: 4 threads
+```
+
+Then Run
+
+```
+docker run --rm -v /your/path/to/model_store:/model_store -p 3000:3000 gagansingh894/jams start -f config.toml
+```
+
+
+
+There are other ways to start J.A.M.S.
 Please follow the following commands to start the server inside docker.
-If you want to disable polling, then do not pass `--poll-interval`
 
-1. Run `docker pull gagansingh894/jams`
+If you want to disable polling, then do not pass `--poll-interval`
 
 To run HTTP server, use
 ```
@@ -118,7 +166,6 @@ docker run --rm -p 3000:3000 gagansingh894/jams start http --with-azure-model-st
 Please refer to [OpenAPI Spec](https://github.com/gagansingh894/jams-rs/blob/main/openapi.yml) for API endpoints.
 
 Alternatively, you can also refer to the [proto definition](https://github.com/gagansingh894/jams-rs/blob/main/internal/jams-proto/proto/api/v1/jams.proto).
-
 ---
 
 ## Local Setup

--- a/build/Dockerfile_grpc
+++ b/build/Dockerfile_grpc
@@ -2,4 +2,4 @@ FROM --platform=linux/amd64 gagansingh894/jams
 LABEL authors="gagandeepsingh"
 RUN mkdir -p /model_store
 COPY build/assets/model_store /model_store
-CMD ["start", "grpc", "--model-dir", "/model_store"]
+CMD ["start", "grpc", "--model-dir", "/model_store", "--poll-interval", "300"]

--- a/build/Dockerfile_http
+++ b/build/Dockerfile_http
@@ -2,4 +2,4 @@ FROM --platform=linux/amd64 gagansingh894/jams
 LABEL authors="gagandeepsingh"
 RUN mkdir -p /model_store
 COPY build/assets/model_store /model_store
-CMD ["start", "http", "--model-dir", "/model_store"]
+CMD ["start", "http", "--model-dir", "/model_store", "--poll-interval", "300"]

--- a/build/run_config/aws_grpc.toml
+++ b/build/run_config/aws_grpc.toml
@@ -3,5 +3,5 @@ protocol = "grpc"
 port = 4000
 model_store = "aws"
 s3_bucket_name = "jamsmodelstore"
-polling = 600 # in seconds
+poll_interval = 600 # in seconds
 num_workers = 4

--- a/build/run_config/aws_grpc.toml
+++ b/build/run_config/aws_grpc.toml
@@ -1,0 +1,7 @@
+[config]
+protocol = "grpc"
+port = 4000
+model_store = "aws"
+s3_bucket_name = "jamsmodelstore"
+polling = 600 # in seconds
+num_workers = 4

--- a/build/run_config/aws_http.toml
+++ b/build/run_config/aws_http.toml
@@ -1,0 +1,7 @@
+[config]
+protocol = "http"
+port = 3000
+model_store = "aws"
+s3_bucket_name = "jamsmodelstore"
+polling = 600 # in seconds
+num_workers = 4

--- a/build/run_config/aws_http.toml
+++ b/build/run_config/aws_http.toml
@@ -3,5 +3,5 @@ protocol = "http"
 port = 3000
 model_store = "aws"
 s3_bucket_name = "jamsmodelstore"
-polling = 600 # in seconds
+poll_interval = 600 # in seconds
 num_workers = 4

--- a/build/run_config/azure_grpc.toml
+++ b/build/run_config/azure_grpc.toml
@@ -2,6 +2,6 @@
 protocol = "grpc"
 port = 4000
 model_store = "azure"
-storage_container_name = "jamsmodelstore"
-polling = 600 # in seconds
+azure_storage_container_name = "jamsmodelstore"
+poll_interval = 600 # in seconds
 num_workers = 4

--- a/build/run_config/azure_grpc.toml
+++ b/build/run_config/azure_grpc.toml
@@ -1,0 +1,7 @@
+[config]
+protocol = "grpc"
+port = 4000
+model_store = "azure"
+storage_container_name = "jamsmodelstore"
+polling = 600 # in seconds
+num_workers = 4

--- a/build/run_config/azure_http.toml
+++ b/build/run_config/azure_http.toml
@@ -2,6 +2,6 @@
 protocol = "http"
 port = 3000
 model_store = "azure"
-storage_container_name = "jamsmodelstore"
-polling = 600 # in seconds
+azure_storage_container_name = "jamsmodelstore"
+poll_interval = 600 # in seconds
 num_workers = 4

--- a/build/run_config/azure_http.toml
+++ b/build/run_config/azure_http.toml
@@ -1,0 +1,7 @@
+[config]
+protocol = "http"
+port = 3000
+model_store = "azure"
+storage_container_name = "jamsmodelstore"
+polling = 600 # in seconds
+num_workers = 4

--- a/build/run_config/local_grpc.toml
+++ b/build/run_config/local_grpc.toml
@@ -1,0 +1,7 @@
+[config]
+protocol = "grpc"
+port = 4000
+model_store = "local"
+model_dir = "/model_store"
+polling = 600 # in seconds
+num_workers = 4

--- a/build/run_config/local_grpc.toml
+++ b/build/run_config/local_grpc.toml
@@ -3,5 +3,5 @@ protocol = "grpc"
 port = 4000
 model_store = "local"
 model_dir = "/model_store"
-polling = 600 # in seconds
+poll_interval = 600 # in seconds
 num_workers = 4

--- a/build/run_config/local_http.toml
+++ b/build/run_config/local_http.toml
@@ -3,5 +3,5 @@ protocol = "http"
 port = 3000
 model_store = "local"
 model_dir = "/model_store"
-polling = 600 # in seconds
+poll_interval = 600 # in seconds
 num_workers = 4

--- a/build/run_config/local_http.toml
+++ b/build/run_config/local_http.toml
@@ -1,0 +1,7 @@
+[config]
+protocol = "http"
+port = 3000
+model_store = "local"
+model_dir = "/model_store"
+polling = 600 # in seconds
+num_workers = 4

--- a/build/run_config/local_http.toml
+++ b/build/run_config/local_http.toml
@@ -1,7 +1,32 @@
 [config]
-protocol = "http"
-port = 3000
-model_store = "local"
-model_dir = "/model_store"
-poll_interval = 600 # in seconds
-num_workers = 4
+protocol = "http"                               # Specifies the protocol to be used by the server.
+                                                # Allowed values: "http", "grpc"
+
+port = 3000                                     # Defines the port number on which the server will listen.
+                                                # This should be an integer between 1 and 65535.
+                                                # Example: 3000 for HTTP, 443 for HTTPS
+
+model_store = "local"                           # Indicates the type of model store being used.
+                                                # Allowed values:
+                                                # - "local": Use local storage.
+                                                # - "aws": Use AWS S3 for model storage.
+                                                # - "azure": Use Azure Blob Storage.
+
+model_dir = "<absolute path>"                   # Specifies the directory path where models are stored locally.
+                                                # If `model_store` is set to "local", this directory is used
+                                                # to store or load models.
+
+azure_storage_container_name = "jamsmodelstore" # Specifies the name of the Azure Blob Storage container
+                                                # used for storing models when `model_store` is set to "azure".
+                                                # This should be a valid container name in Azure.
+
+s3_bucket_name = "jamsmodelstore"               # Indicates the name of the S3 bucket used for storing models
+                                                # when `model_store` is set to "aws".
+                                                # This should be a valid bucket name in AWS S3.
+
+poll_interval = 600                             # Defines the time interval (in seconds) for polling the model store
+                                                # to check for updates.
+                                                # Example: 600 means the application will poll every 10 minutes.
+
+num_workers = 4                                 # Sets the number of Rayon threadpool worker threads
+                                                # Example: 4 threads

--- a/jams/Cargo.toml
+++ b/jams/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jams"
 description = "jams is an easy-to-use CLI application for interaction with J.A.M.S - Just Another Model Server"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2021"
 homepage = "https://github.com/gagansingh894/jams-rs"
 repository = "https://github.com/gagansingh894/jams-rs/tree/main/jams"
@@ -21,3 +21,5 @@ anyhow = "1.0.86"
 tokio = "1.38.0"
 log = "0.4.21"
 tracing = "0.1.40"
+serde = { version = "1.0.210", features = ["derive"] }
+toml = "0.8.19"

--- a/jams/README.md
+++ b/jams/README.md
@@ -4,8 +4,8 @@ This crate provides a CLI for interacting [**J.A.M.S - Just Another Model Server
 
 ![Alt text](https://github.com/gagansingh894/jams-rs/blob/main/jams/screenshot.png?raw=true)
 
-⚠️ **DISCLAIMER: jams is currently unstable and may not run properly on your machines. I have
-tested the above on Apple Silicon and Linux x86_64 machines. Future releases will fix this**
+⚠️ **DISCLAIMER: jams is currently unstable and may not run properly on ARM chips. Future releases will fix this.
+For now use docker image (Linux x86_64)**
 ---
 
 ## Features
@@ -34,12 +34,58 @@ tested the above on Apple Silicon and Linux x86_64 machines. Future releases wil
 ---
 
 ## Docker Setup
-J.A.M.S is also hosted on [DockerHub](https://hub.docker.com/r/gagansingh894/jams).
+J.A.M.S is also on [DockerHub](https://hub.docker.com/r/gagansingh894/jams).
 
+`docker pull gagansingh894/jams`
+
+The easiest way to start J.A.M.S is by providing a config TOML file
+
+##### Config File
+```
+[config]
+protocol = "http"                               # Specifies the protocol to be used by the server.
+                                                # Allowed values: "http", "grpc"
+
+port = 3000                                     # Defines the port number on which the server will listen.
+                                                # This should be an integer between 1 and 65535.
+                                                # Example: 3000 for HTTP, 443 for HTTPS
+
+model_store = "local"                           # Indicates the type of model store being used.
+                                                # Allowed values:
+                                                # - "local": Use local storage.
+                                                # - "aws": Use AWS S3 for model storage.
+                                                # - "azure": Use Azure Blob Storage.
+
+model_dir = "<absolute path>"                   # Specifies the directory path where models are stored locally.
+                                                # If `model_store` is set to "local", this directory is used
+                                                # to store or load models.
+
+azure_storage_container_name = "jamsmodelstore" # Specifies the name of the Azure Blob Storage container
+                                                # used for storing models when `model_store` is set to "azure".
+                                                # This should be a valid container name in Azure.
+
+s3_bucket_name = "jamsmodelstore"               # Indicates the name of the S3 bucket used for storing models
+                                                # when `model_store` is set to "aws".
+                                                # This should be a valid bucket name in AWS S3.
+
+poll_interval = 600                             # Defines the time interval (in seconds) for polling the model store
+                                                # to check for updates.
+                                                # Example: 600 means the application will poll every 10 minutes.
+
+num_workers = 4                                 # Sets the number of Rayon threadpool worker threads
+                                                # Example: 4 threads
+```
+
+Then Run
+
+```
+docker run --rm -v /your/path/to/model_store:/model_store -p 3000:3000 gagansingh894/jams start -f config.toml
+```
+
+There are other ways to start J.A.M.S. 
 Please follow the following commands to start the server inside docker. 
-If you want to disable polling, then do not pass `--poll-interval`
 
-1. Run `docker pull gagansingh894/jams`
+If you want to disable polling, then do not pass `--poll-interval`
 
 To run HTTP server, use
 ```

--- a/jams/src/cli.rs
+++ b/jams/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Args, Parser, Subcommand};
 use jams_core::model::predictor::Predictor;
+use serde::Deserialize;
 use std::fs;
 
 /// CLI for starting an J.A.M.S
@@ -29,7 +30,10 @@ pub enum Commands {
 #[derive(Parser, Debug)]
 pub struct StartCommands {
     #[clap(subcommand)]
-    pub cmd: StartSubCommands,
+    pub cmd: Option<StartSubCommands>,
+
+    #[arg(short = 'f', long)]
+    pub file: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -111,6 +115,25 @@ pub struct PredictCommandArgs {
     /// Path to JSON file containing input data
     #[clap(long)]
     pub input_path: Option<String>,
+}
+
+// Top level struct to hold the TOML data.
+#[derive(Deserialize)]
+pub struct Data {
+    pub config: Config,
+}
+
+// Config struct holds to data from the `[config]` section.
+#[derive(Deserialize)]
+struct Config {
+    pub protocol: String,
+    pub port: Option<u16>,
+    pub store: String,
+    pub num_workers: Option<usize>,
+    pub poll_interval: Option<u64>,
+    pub model_dor: Option<String>,
+    pub azure_storage_container_name: Option<String>,
+    pub s3_bucket_name: Option<String>,
 }
 
 pub fn predict(

--- a/jams/src/cli.rs
+++ b/jams/src/cli.rs
@@ -32,6 +32,7 @@ pub struct StartCommands {
     #[clap(subcommand)]
     pub cmd: Option<StartSubCommands>,
 
+    /// Path to config file
     #[arg(short = 'f', long)]
     pub file: Option<String>,
 }
@@ -125,13 +126,13 @@ pub struct Data {
 
 // Config struct holds to data from the `[config]` section.
 #[derive(Deserialize)]
-struct Config {
+pub struct Config {
     pub protocol: String,
     pub port: Option<u16>,
-    pub store: String,
+    pub model_store: String,
     pub num_workers: Option<usize>,
     pub poll_interval: Option<u64>,
-    pub model_dor: Option<String>,
+    pub model_dir: Option<String>,
     pub azure_storage_container_name: Option<String>,
     pub s3_bucket_name: Option<String>,
 }

--- a/jams/src/cli.rs
+++ b/jams/src/cli.rs
@@ -7,7 +7,7 @@ use std::fs;
 #[derive(Parser, Debug)]
 #[clap(
     name = "J.A.M.S - Just Another Model Server",
-    version = "0.1.0",
+    version = "0.1.20",
     author = "Gagandeep Singh",
     about = "J.A.M.S aims to provide a fast, comprehensive and modular serving solution for tree based and deep learning models written in Rust 🦀"
 )]

--- a/jams/src/main.rs
+++ b/jams/src/main.rs
@@ -1,7 +1,14 @@
-use crate::cli::{predict, Commands, PredictSubCommands, StartSubCommands};
+use crate::cli::{predict, Commands, PredictSubCommands, StartSubCommands, Data};
 use clap::Parser;
+use std::fs;
 
 mod cli;
+
+const GRPC: &'static str = "grpc";
+const HTTP: &'static str = "http";
+const LOCAL: &'static str = "local";
+const AZURE: &'static str = "azure";
+const AWS: &'static str = "aws";
 
 #[cfg(not(tarpaulin_include))]
 #[tokio::main]
@@ -29,48 +36,104 @@ J.A.M.S - Just Another Model Server
 
     match cli.cmd {
         Commands::Start(subcommands) => {
-            match subcommands.cmd {
-                StartSubCommands::Http(args) => {
-                    let config = jams_serve::common::server::Config {
-                        model_dir: args.model_dir,
-                        port: args.port,
-                        use_debug_level: args.use_debug_level,
-                        num_workers: args.num_workers,
-                        with_s3_model_store: args.with_s3_model_store,
-                        s3_bucket_name: args.s3_bucket_name,
-                        with_azure_model_store: args.with_azure_model_store,
-                        azure_storage_container_name: args.azure_storage_container_name,
-                        poll_interval: args.poll_interval,
+            match subcommands.file {
+                Some(file_path) => {
+                    let contents = match fs::read_to_string(file_path) {
+                        Ok(c) => c,
+                        Err(e) => {
+                            anyhow::bail!("Failed to read config file ❌: {}", e.to_string())
+                        }
                     };
 
-                    jams_serve::http::server::start(config)
-                        .await
-                        .expect("Failed to start server ❌ \n");
+                    let config_data: Data = match toml::from_str(contents.as_str()) {
+                        Ok(config_data) => config_data,
+                        Err(e) => {
+                            anyhow::bail!("Failed to parse config file ❌: {}", e.to_string())
+                        }
+                    };
 
-                    // shutdown signal received
-                    tracing::error!("Shutdown signal received ⚠️");
-                    Ok(())
+                    let config = jams_serve::common::server::Config {
+                        model_dir: config_data.config.model_dor,
+                        port: config_data.config.port,
+                        use_debug_level: Some(false),
+                        num_workers: config_data.config.num_workers,
+                        with_s3_model_store: Some(config_data.config.store == AWS),
+                        s3_bucket_name: config_data.config.s3_bucket_name,
+                        with_azure_model_store: Some(config_data.config.store == AZURE),
+                        azure_storage_container_name: config_data
+                            .config
+                            .azure_storage_container_name,
+                        poll_interval: config_data.config.poll_interval,
+                    };
+
+                    if config_data.config.protocol == GRPC {
+                        jams_serve::grpc::server::start(config)
+                            .await
+                            .expect("Failed to start server ❌ \n");
+
+                        // shutdown signal received
+                        tracing::error!("Shutdown signal received ⚠️");
+                        Ok(())
+                    } else {
+                        jams_serve::http::server::start(config)
+                            .await
+                            .expect("Failed to start server ❌ \n");
+
+                        // shutdown signal received
+                        tracing::error!("Shutdown signal received ⚠️");
+                        Ok(())
+                    }
                 }
-                StartSubCommands::Grpc(args) => {
-                    let config = jams_serve::common::server::Config {
-                        model_dir: args.model_dir,
-                        port: args.port,
-                        use_debug_level: args.use_debug_level,
-                        num_workers: args.num_workers,
-                        with_s3_model_store: args.with_s3_model_store,
-                        s3_bucket_name: args.s3_bucket_name,
-                        with_azure_model_store: args.with_azure_model_store,
-                        azure_storage_container_name: args.azure_storage_container_name,
-                        poll_interval: args.poll_interval,
-                    };
+                None => {
+                    match subcommands.cmd {
+                        None => {
+                            anyhow::bail!(
+                        "Either pass path to config file using -f or use http/grpc subcommands "
+                    );
+                        }
+                        Some(StartSubCommands::Http(args)) => {
+                            let config = jams_serve::common::server::Config {
+                                model_dir: args.model_dir,
+                                port: args.port,
+                                use_debug_level: args.use_debug_level,
+                                num_workers: args.num_workers,
+                                with_s3_model_store: args.with_s3_model_store,
+                                s3_bucket_name: args.s3_bucket_name,
+                                with_azure_model_store: args.with_azure_model_store,
+                                azure_storage_container_name: args.azure_storage_container_name,
+                                poll_interval: args.poll_interval,
+                            };
 
-                    jams_serve::grpc::server::start(config)
-                        .await
-                        .expect("Failed to start server ❌ \n");
+                            jams_serve::http::server::start(config)
+                                .await
+                                .expect("Failed to start server ❌ \n");
 
-                    // shutdown signal received
-                    tracing::error!("Shutdown signal received ⚠️");
-                    Ok(())
+                            // shutdown signal received
+                            tracing::error!("Shutdown signal received ⚠️");
+                            Ok(())
+                        }
+                        Some(StartSubCommands::Grpc(args)) => {
+                            let config = jams_serve::common::server::Config {
+                                model_dir: args.model_dir,
+                                port: args.port,
+                                use_debug_level: args.use_debug_level,
+                                num_workers: args.num_workers,
+                                with_s3_model_store: args.with_s3_model_store,
+                                s3_bucket_name: args.s3_bucket_name,
+                                with_azure_model_store: args.with_azure_model_store,
+                                azure_storage_container_name: args.azure_storage_container_name,
+                                poll_interval: args.poll_interval,
+                            };
+
+                            jams_serve::grpc::server::start(config)
+                                .await
+                                .expect("Failed to start server ❌ \n");
+
+                            // shutdown signal received
+                            tracing::error!("Shutdown signal received ⚠️");
+                            Ok(())
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds support for config files. The user can now start the application by specifiying the a config TOML file 

**Config File**

```
[config]
protocol = "http"                               # Specifies the protocol to be used by the server.
                                                # Allowed values: "http", "grpc"

port = 3000                                     # Defines the port number on which the server will listen.
                                                # This should be an integer between 1 and 65535.
                                                # Example: 3000 for HTTP, 443 for HTTPS

model_store = "local"                           # Indicates the type of model store being used.
                                                # Allowed values:
                                                # - "local": Use local storage.
                                                # - "aws": Use AWS S3 for model storage.
                                                # - "azure": Use Azure Blob Storage.

model_dir = "<absolute path>"                   # Specifies the directory path where models are stored locally.
                                                # If `model_store` is set to "local", this directory is used
                                                # to store or load models.

azure_storage_container_name = "jamsmodelstore" # Specifies the name of the Azure Blob Storage container
                                                # used for storing models when `model_store` is set to "azure".
                                                # This should be a valid container name in Azure.

s3_bucket_name = "jamsmodelstore"               # Indicates the name of the S3 bucket used for storing models
                                                # when `model_store` is set to "aws".
                                                # This should be a valid bucket name in AWS S3.

poll_interval = 600                             # Defines the time interval (in seconds) for polling the model store
                                                # to check for updates.
                                                # Example: 600 means the application will poll every 10 minutes.

num_workers = 4                                 # Sets the number of Rayon threadpool worker threads
                                                # Example: 4 threads
```

Then Run

```
docker run --rm -v /your/path/to/model_store:/model_store -p 3000:3000 gagansingh894/jams start -f config.toml
```