### PR TITLE
feat: use runtime builder and better configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,13 +2037,14 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jams"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "anyhow",
  "clap",
  "jams-core",
  "jams-serve",
  "log",
+ "num_cpus",
  "serde",
  "tokio",
  "tracing",
@@ -2116,7 +2117,6 @@ dependencies = [
  "jams-core",
  "jams-proto",
  "log",
- "num_cpus",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions 0.15.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "jams-serve"
-version = "0.1.30"
+version = "0.1.31"
 dependencies = [
  "anyhow",
  "axum 0.7.7",
@@ -2116,6 +2116,7 @@ dependencies = [
  "jams-core",
  "jams-proto",
  "log",
+ "num_cpus",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions 0.15.0",
@@ -2414,6 +2415,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ which provides thin abstraction around common machine learning and deep learning
 Azure Blob Storage, Local Filesystem.
 You can think of each component as a LEGO block which can be used to build a system depending on the requirements
 
-`jams-proto` is provides the gRPC contract for jams-serve.
+`jams-proto` provides the gRPC contract for jams-serve.
 
 `jams-serve` is a http and gRPC API library for jams-core.
 The API is highly configurable, allowing the user to select which components to use when setting up the model server.

--- a/build/run_config/minio_grpc.toml
+++ b/build/run_config/minio_grpc.toml
@@ -4,4 +4,3 @@ port = 4000
 model_store = "minio"
 s3_bucket_name = "jamsmodelstore"
 poll_interval = 30 # in seconds
-num_workers = 4

--- a/build/run_config/minio_http.toml
+++ b/build/run_config/minio_http.toml
@@ -4,4 +4,3 @@ port = 3000
 model_store = "minio"
 s3_bucket_name = "jamsmodelstore"
 poll_interval = 30 # in seconds
-num_workers = 4

--- a/jams-serve/Cargo.toml
+++ b/jams-serve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jams-serve"
-version = "0.1.30"
+version = "0.1.31"
 edition = "2021"
 description = "jams-serve provides a http and gRPC API for jams-core."
 homepage = "https://github.com/gagansingh894/jams-rs"
@@ -35,6 +35,7 @@ opentelemetry-otlp = "0.15.0"
 opentelemetry-semantic-conventions = "0.15.0"
 tracing-opentelemetry = "0.23.0"
 toml = "0.8.19"
+num_cpus = "1.16.0"
 
 [dev-dependencies]
 chrono = "0.4.38"

--- a/jams-serve/Cargo.toml
+++ b/jams-serve/Cargo.toml
@@ -35,7 +35,6 @@ opentelemetry-otlp = "0.15.0"
 opentelemetry-semantic-conventions = "0.15.0"
 tracing-opentelemetry = "0.23.0"
 toml = "0.8.19"
-num_cpus = "1.16.0"
 
 [dev-dependencies]
 chrono = "0.4.38"

--- a/jams-serve/src/common/state.rs
+++ b/jams-serve/src/common/state.rs
@@ -40,7 +40,10 @@ pub struct AppState {
 /// * `MODEL_STORE_DIR` - The directory to store models locally (optional).
 /// * `S3_BUCKET_NAME` - The name of the S3 bucket to store models (required if `with_s3_model_store` is true).
 ///
-pub async fn build_app_state_from_config(config: server::Config) -> anyhow::Result<Arc<AppState>> {
+pub async fn build_app_state(
+    config: server::Config,
+    worker_pool_threads: usize,
+) -> anyhow::Result<Arc<AppState>> {
     instrument::simple::init(tracing::Level::INFO);
 
     let model_dir = config.model_dir.unwrap_or_else(|| {
@@ -48,7 +51,7 @@ pub async fn build_app_state_from_config(config: server::Config) -> anyhow::Resu
         env::var("MODEL_STORE_DIR").unwrap_or_else(|_| "".to_string())
     });
 
-    let worker_pool_threads = config.num_workers.unwrap_or(2);
+    let worker_pool_threads = config.num_workers.unwrap_or(worker_pool_threads);
     let model_store = config.model_store;
 
     // run without polling by default

--- a/jams-serve/src/lib.rs
+++ b/jams-serve/src/lib.rs
@@ -4,17 +4,37 @@ pub mod http;
 
 use crate::common::server;
 use crate::common::server::HTTP;
-use crate::common::state::build_app_state_from_config;
+use crate::common::state::build_app_state;
+use tokio::runtime::Builder;
 
 pub async fn start(config: server::Config) {
+    // get physical cpu count and divide by 2.
+    // one half is given to tokio runtime and the another to rayon thread pool.
+    // the rayon threadpool worker count acan also be set via config/flag
+    let physical_cores = num_cpus::get_physical();
+    let half_physical_cores = (physical_cores / 2).max(1);
+
+    let tokio_runtime = Builder::new_multi_thread()
+        .worker_threads(half_physical_cores)
+        .max_blocking_threads(50)
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime");
+
+    tracing::info!(
+        "Tokio runtime configured with {} worker threads ⚙️",
+        half_physical_cores
+    );
+
     // print terminal art
     println!("{}", server::ART);
 
     // init port number
-    let port = config.port.unwrap_or(3000);
+    let http_port = config.port.unwrap_or(3000);
+    let grpc_port = config.port.unwrap_or(4000);
 
     // setup shared state
-    let shared_state = match build_app_state_from_config(config.clone()).await {
+    let shared_state = match build_app_state(config.clone(), half_physical_cores).await {
         Ok(state) => state,
         Err(e) => {
             tracing::error!(
@@ -25,12 +45,19 @@ pub async fn start(config: server::Config) {
         }
     };
 
-    if config.protocol == HTTP {
-        http::server::start(shared_state, port).await.expect("")
-    } else {
-        // start grpc server
-        grpc::server::start(shared_state, port).await.expect("")
-    }
+    tokio_runtime.block_on(async move {
+        if config.protocol == HTTP {
+            // Start HTTP server
+            http::server::start(shared_state, http_port)
+                .await
+                .expect("Failed to start HTTP server");
+        } else {
+            // Start gRPC server
+            grpc::server::start(shared_state, grpc_port)
+                .await
+                .expect("Failed to start gRPC server");
+        }
+    });
 }
 
 #[cfg(test)]

--- a/jams/Cargo.toml
+++ b/jams/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jams"
 description = "jams is an easy-to-use CLI application for interaction with J.A.M.S - Just Another Model Server"
-version = "0.1.24"
+version = "0.1.25"
 edition = "2021"
 homepage = "https://github.com/gagansingh894/jams-rs"
 repository = "https://github.com/gagansingh894/jams-rs/tree/main/jams"
@@ -22,3 +22,4 @@ tokio = "1.38.0"
 log = "0.4.21"
 tracing = "0.1.40"
 serde = { version = "1.0.210", features = ["derive"] }
+num_cpus = "1.16.0"


### PR DESCRIPTION
This PR updates the logic of allocating worker threads to both Tokio and Rayon based on Physical core count. The cores are divided by 2 and allocated. If Division is not possible then atleast 1 is allocated to both
